### PR TITLE
Fix self-damage check in AdvancedFriendlyFireHook

### DIFF
--- a/advanced_friendlyfire.cs
+++ b/advanced_friendlyfire.cs
@@ -151,7 +151,7 @@ namespace AdvancedFriendlyFire
             var attacker = new CCSPlayerPawn(idmg.Attacker.Value.Handle);
             var victimPlayer = new CCSPlayerController(victim.Handle);
 
-            if (attacker.TeamNum != victimPlayer.TeamNum || attacker == victimPlayer) return HookResult.Continue;
+            if (attacker.TeamNum != victimPlayer.TeamNum || attackerController.SteamID == victimPlayer.SteamID) return HookResult.Continue;
 
             string inflictor = idmg.Inflictor.Value?.DesignerName ?? "";
 


### PR DESCRIPTION
## Summary
- ensure self-inflicted damage is ignored by comparing attacker and victim via SteamID in AdvancedFriendlyFireHook

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c828c328b88322a4c75af8fa5cd769