### PR TITLE
Allow non-listed inflictors

### DIFF
--- a/advanced_friendlyfire.cs
+++ b/advanced_friendlyfire.cs
@@ -219,7 +219,7 @@ namespace AdvancedFriendlyFire
 
                 return HookResult.Continue;
             }
-            return HookResult.Handled;
+            return HookResult.Continue;
         }
 
     }


### PR DESCRIPTION
## Summary
- allow damage from unspecified inflictors by returning `HookResult.Continue`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c828d877388322b4fe598959df1133