### PR TITLE
chore: remove unused using directives

### DIFF
--- a/advanced_friendlyfire.cs
+++ b/advanced_friendlyfire.cs
@@ -1,14 +1,8 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using System.Text.Json.Serialization;
 using CounterStrikeSharp.API.Modules.Memory.DynamicFunctions;
 using CounterStrikeSharp.API.Modules.Memory;
-using CounterStrikeSharp.API.Core.Attributes.Registration;
-using CounterStrikeSharp.API.Modules.Commands;
-using System.Reflection;
 
 namespace AdvancedFriendlyFire
 { 


### PR DESCRIPTION
## Summary
- tidy up advanced_friendlyfire.cs by removing unused using directives

## Testing
- `dotnet build` *(fails: command not found; dotnet SDK unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c828d9dae0832280f0e48efd721cc5