### PR TITLE
Block friendly fire from disallowed sources

### DIFF
--- a/advanced_friendlyfire.cs
+++ b/advanced_friendlyfire.cs
@@ -118,65 +118,67 @@ namespace AdvancedFriendlyFire
 
             string inflictor = idmg.Inflictor.Value?.DesignerName ?? "";
 
-            if (Config.DamageInflictors.Contains(inflictor))
+            if (!Config.DamageInflictors.Contains(inflictor))
             {
-                attackerController.PrintToCenterAlert("DON'T HURT YOUR TEAMMATES!");
-
-                if (Config.ArePunishmentsEnabled)
-                {
-                    ulong attackerSteamId = attacker.Controller.Value.SteamID;
-                    float damageAmount = idmg.Damage;
-                    string attackerName = attackerController.PlayerName;
-
-                    if (!teamDamageTracker.TryGetValue(attackerSteamId, out float totalDamage))
-                        totalDamage = 0;
-
-                    totalDamage += damageAmount;
-                    teamDamageTracker[attackerSteamId] = totalDamage;
-
-                    //Server.PrintToChatAll($"Total damage: {teamDamageTracker[attackerSteamId]}");
-
-                    if (!punishmentLevelTracker.TryGetValue(attackerSteamId, out int punishmentLevel))
-                        punishmentLevel = 0;
-
-                    if (totalDamage >= Config.Warn1 && punishmentLevel < 1)
-                    {
-                        attackerController.PrintToChat($"{Config.chatWarn1}");
-
-                        string commandToExecute = Config.punishWarn1;
-
-                        if (commandToExecute.Contains("{Player}"))
-                            Server.ExecuteCommand(commandToExecute.Replace("{Player}", attackerName));
-
-                        punishmentLevelTracker[attackerSteamId] = 1;
-                    }
-                    else if (totalDamage >= Config.Warn2 && punishmentLevel < 2)
-                    {
-                        attackerController.PrintToChat($"{Config.chatWarn2}");
-
-                        string commandToExecute = Config.punishWarn2;
-
-                        if (commandToExecute.Contains("{Player}"))
-                            Server.ExecuteCommand(commandToExecute.Replace("{Player}", attackerName));
-
-                        punishmentLevelTracker[attackerSteamId] = 2;
-                    }
-                    else if (totalDamage >= Config.Warn3 && punishmentLevel < 3)
-                    {
-                        attackerController.PrintToChat($"{Config.chatWarn3}");
-
-                        string commandToExecute = Config.punishWarn3;
-
-                        if (commandToExecute.Contains("{Player}"))
-                            Server.ExecuteCommand(commandToExecute.Replace("{Player}", attackerName));
-
-                        teamDamageTracker[attackerSteamId] = 0;
-                        punishmentLevelTracker[attackerSteamId] = 0;
-                    }
-                }
-
-                return HookResult.Continue;
+                idmg.Damage = 0;
+                return HookResult.Stop;
             }
+
+            attackerController.PrintToCenterAlert("DON'T HURT YOUR TEAMMATES!");
+
+            if (Config.ArePunishmentsEnabled)
+            {
+                ulong attackerSteamId = attacker.Controller.Value.SteamID;
+                float damageAmount = idmg.Damage;
+                string attackerName = attackerController.PlayerName;
+
+                if (!teamDamageTracker.TryGetValue(attackerSteamId, out float totalDamage))
+                    totalDamage = 0;
+
+                totalDamage += damageAmount;
+                teamDamageTracker[attackerSteamId] = totalDamage;
+
+                //Server.PrintToChatAll($"Total damage: {teamDamageTracker[attackerSteamId]}");
+
+                if (!punishmentLevelTracker.TryGetValue(attackerSteamId, out int punishmentLevel))
+                    punishmentLevel = 0;
+
+                if (totalDamage >= Config.Warn1 && punishmentLevel < 1)
+                {
+                    attackerController.PrintToChat($"{Config.chatWarn1}");
+
+                    string commandToExecute = Config.punishWarn1;
+
+                    if (commandToExecute.Contains("{Player}"))
+                        Server.ExecuteCommand(commandToExecute.Replace("{Player}", attackerName));
+
+                    punishmentLevelTracker[attackerSteamId] = 1;
+                }
+                else if (totalDamage >= Config.Warn2 && punishmentLevel < 2)
+                {
+                    attackerController.PrintToChat($"{Config.chatWarn2}");
+
+                    string commandToExecute = Config.punishWarn2;
+
+                    if (commandToExecute.Contains("{Player}"))
+                        Server.ExecuteCommand(commandToExecute.Replace("{Player}", attackerName));
+
+                    punishmentLevelTracker[attackerSteamId] = 2;
+                }
+                else if (totalDamage >= Config.Warn3 && punishmentLevel < 3)
+                {
+                    attackerController.PrintToChat($"{Config.chatWarn3}");
+
+                    string commandToExecute = Config.punishWarn3;
+
+                    if (commandToExecute.Contains("{Player}"))
+                        Server.ExecuteCommand(commandToExecute.Replace("{Player}", attackerName));
+
+                    teamDamageTracker[attackerSteamId] = 0;
+                    punishmentLevelTracker[attackerSteamId] = 0;
+                }
+            }
+
             return HookResult.Continue;
         }
 


### PR DESCRIPTION
## Summary
- Ignore friendly fire from non-whitelisted damage sources by zeroing damage and stopping the hook
- Preserve punishment flow for configured grenade inflictors

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c836a334bc83228425e8812d7d5fe3